### PR TITLE
1文字ごとのタイムを記録して表示する

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -105,18 +105,26 @@ jQuery(function($) {
   let latencies = [];
   let misses = [];
   let times = [];
+  let charTimes = [];
+  let missTimes = [];
   let finishedCount = 0;
   let wordStartTime;
   let wordMiss = 0;
+  let wordCharTimes = [];
+  let wordMissTimes = [];
   let previousResult = {};
   const handleShowWord = () => {
     wordStartTime = Date.now();
     wordMiss = 0;
+    wordCharTimes = [];
+    wordMissTimes = [];
   };
   const handleFinishWord = () => {
     const wordTime = Date.now() - wordStartTime;
     times.push(wordTime);
     misses.push(wordMiss);
+    charTimes.push(wordCharTimes);
+    missTimes.push(wordMissTimes);
     finishedCount += 1;
 
     hideLatencyBalloon();
@@ -131,19 +139,27 @@ jQuery(function($) {
     }
   };
   const handleAccept = () => {
+    const time = Date.now() - wordStartTime;
+    wordCharTimes.push(time);
   };
   const handleMiss = () => {
+    const time = Date.now() - wordStartTime;
+    wordMissTimes.push(time);
     wordMiss += 1;
   };
   const handleEscape = () => {
     const time = Date.now() - wordStartTime;
     times.push(time);
     misses.push(wordMiss);
+    charTimes.push(wordCharTimes);
+    missTimes.push(wordMissTimes);
 
     hideLatencyBalloon();
   };
   const handleShowResult = () => {
+    // TODO: 消す
     console.log({ misses, times, latencies, finishedCount });
+    console.log({ charTimes, missTimes });
 
     // ワード詳細
     for (let i = 0; i < finishedCount; i++) {

--- a/src/app.js
+++ b/src/app.js
@@ -184,6 +184,14 @@ jQuery(function($) {
     hideLatencyBalloon();
   };
   const handleShowResult = () => {
+    const resultMissCount = +$('#current .result_data ul .title:contains("ミス入力数")').next().text();
+    if (misses.reduce((a, b) => a + b, 0) === resultMissCount - 1) {
+      // 1足りない == LT 機能でミスって終わった
+      const lastWordMissTimes = missTimes[missTimes.length - 1];
+      lastWordMissTimes[lastWordMissTimes.length - 1].push(0);
+      misses[misses.length - 1] += 1;
+    }
+
     // TODO: 消す
     console.log({ misses, times, latencies });
     console.log({ charTimes, missTimes });
@@ -202,13 +210,13 @@ jQuery(function($) {
         const $key = $('<span>').text(k);
         if (missTimes[i][j] == null) return $key.fadeTo(0, 0.6);
 
-        const loss = Math.max(...missTimes[i][j], 0);
-        if (loss > 0) {
+        const loss = Math.max(...missTimes[i][j], -Infinity);
+        if (loss >= 0) {
           $key.addClass('miss');
         }
         if (charTimes[i][j] == null) return $key.fadeTo(0, 0.6);
 
-        const toolTip = loss > 0
+        const toolTip = loss >= 0
             ? `${(charTimes[i][j] / 1000).toFixed(3)} (${(loss / 1000).toFixed(3)})`
             : `${(charTimes[i][j] / 1000).toFixed(3)}`;
         // FIXME: 共通化。全画面の方コピペで定義してるので変えるときは一緒に変えてください

--- a/src/app.js
+++ b/src/app.js
@@ -47,6 +47,7 @@ const initializeExpandedResult = () => {
   // FIXME: 共通化
   $('#exampleList li .sentence span[data-tooltip]').each((_, e) => {
     $(e).balloon({
+      classname: 'time-balloon',
       contents: $(e).data('tooltip'),
       showDuration: 64,
       minLifetime: 0,
@@ -212,6 +213,7 @@ jQuery(function($) {
             : `${(charTimes[i][j] / 1000).toFixed(3)}`;
         // FIXME: 共通化。全画面の方コピペで定義してるので変えるときは一緒に変えてください
         return $key.attr('data-tooltip', toolTip).balloon({
+          classname: 'time-balloon',
           contents: toolTip,
           showDuration: 64,
           minLifetime: 0,
@@ -313,9 +315,14 @@ jQuery(function($) {
     latencyTarget1 = parseFloat(configDiv.dataset.latencyTarget1) * 1000;
     latencyTarget2 = parseFloat(configDiv.dataset.latencyTarget2) * 1000;
   };
+  const removeTimeBalloons = () => {
+    $('.time-balloon').remove();
+  };
 
   const handleLoadStartView = () => {
     updateConfig();
+    // リザルトで文字別タイムが表示されたまま R でリトライするとツールチップが残ったままになる
+    removeTimeBalloons();
 
     // タイピング終了時に毎回削除されるので毎回設定する
     // jQuery#on で設定した関数内で例外が発生すると後続の関数も実行されなくなるので例外は潰す

--- a/src/app.js
+++ b/src/app.js
@@ -109,15 +109,18 @@ jQuery(function($) {
   let missTimes = [];
   let finishedCount = 0;
   let wordStartTime;
+  let charStartTime;
   let wordMiss = 0;
   let wordCharTimes = [];
   let wordMissTimes = [];
+  let charMissTimes = [];
   let previousResult = {};
   const handleShowWord = () => {
-    wordStartTime = Date.now();
+    wordStartTime = charStartTime = Date.now();
     wordMiss = 0;
     wordCharTimes = [];
     wordMissTimes = [];
+    charMissTimes = [];
   };
   const handleFinishWord = () => {
     const wordTime = Date.now() - wordStartTime;
@@ -139,18 +142,22 @@ jQuery(function($) {
     }
   };
   const handleAccept = () => {
-    const time = Date.now() - wordStartTime;
+    const time = Date.now() - charStartTime;
     wordCharTimes.push(time);
+    wordMissTimes.push(charMissTimes);
+    charStartTime += time;
+    charMissTimes = [];
   };
   const handleMiss = () => {
-    const time = Date.now() - wordStartTime;
-    wordMissTimes.push(time);
+    const time = Date.now() - charStartTime;
+    charMissTimes.push(time);
     wordMiss += 1;
   };
   const handleEscape = () => {
     const time = Date.now() - wordStartTime;
     times.push(time);
     misses.push(wordMiss);
+    wordMissTimes.push(charMissTimes);
     charTimes.push(wordCharTimes);
     missTimes.push(wordMissTimes);
 
@@ -198,6 +205,8 @@ jQuery(function($) {
 
     misses = [];
     times = [];
+    charTimes = [];
+    missTimes = [];
     latencies = [];
     finishedCount = 0;
     previousResult = { latency, rkpm };

--- a/src/app.js
+++ b/src/app.js
@@ -42,6 +42,24 @@ const initializeExpandedResult = () => {
   }
   adjustHeight();
   $(window).on('resize', () => adjustHeight());
+
+  // 文字別タイム表示
+  // FIXME: 共通化
+  $('#exampleList li .sentence span[data-tooltip]').each((_, e) => {
+    $(e).balloon({
+      contents: $(e).data('tooltip'),
+      showDuration: 64,
+      minLifetime: 0,
+      tipSize: 0,
+      showAnimation(d, c) { this.fadeIn(d, c); },
+      css: {
+        backgroundColor: '#f7f7f7',
+        color: '#636363',
+        boxShadow: '0',
+        opacity: 1,
+      },
+    });
+  });
 };
 
 // タイピング画面に注入される
@@ -96,6 +114,8 @@ jQuery(function($) {
     Array.from($('head>link[rel="stylesheet"]'), style => newDoc.write(style.outerHTML));
     // TODO: src/ の中から読む
     newDoc.write('<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>');
+    const balloonJsSrc = Array.from(document.scripts, s => s.src).filter(s => s.includes('jquery.balloon'))[0];
+    newDoc.write(`<script type="text/javascript" src="${balloonJsSrc}"></script>`);
     newDoc.write($('<script>').text(`( ${initializeExpandedResult.toString()} )()`).get(0).outerHTML);
   };
 
@@ -190,8 +210,8 @@ jQuery(function($) {
         const toolTip = loss > 0
             ? `${(charTimes[i][j] / 1000).toFixed(3)} (${(loss / 1000).toFixed(3)})`
             : `${(charTimes[i][j] / 1000).toFixed(3)}`;
-        // FIXME: 全画面にすると出ない
-        return $key.attr('data-time', toolTip).balloon({
+        // FIXME: 共通化。全画面の方コピペで定義してるので変えるときは一緒に変えてください
+        return $key.attr('data-tooltip', toolTip).balloon({
           contents: toolTip,
           showDuration: 64,
           minLifetime: 0,
@@ -199,9 +219,9 @@ jQuery(function($) {
           showAnimation(d, c) { this.fadeIn(d, c); },
           css: {
             backgroundColor: '#f7f7f7',
-            color: '#027fff',
-            fontWeight: 'bold',
+            color: '#636363',
             boxShadow: '0',
+            opacity: 1,
           },
         });
       });

--- a/src/app.js
+++ b/src/app.js
@@ -187,11 +187,23 @@ jQuery(function($) {
         }
         if (charTimes[i][j] == null) return $key.fadeTo(0, 0.6);
 
-        if (loss > 0) {
-          return $key.attr('title', `${(charTimes[i][j] / 1000).toFixed(3)} (${(loss / 1000).toFixed(3)})`);
-        } else {
-          return $key.attr('title', `${(charTimes[i][j] / 1000).toFixed(3)}`);
-        }
+        const toolTip = loss > 0
+            ? `${(charTimes[i][j] / 1000).toFixed(3)} (${(loss / 1000).toFixed(3)})`
+            : `${(charTimes[i][j] / 1000).toFixed(3)}`;
+        // FIXME: 全画面にすると出ない
+        return $key.attr('data-time', toolTip).balloon({
+          contents: toolTip,
+          showDuration: 64,
+          minLifetime: 0,
+          tipSize: 0,
+          showAnimation(d, c) { this.fadeIn(d, c); },
+          css: {
+            backgroundColor: '#f7f7f7',
+            color: '#027fff',
+            fontWeight: 'bold',
+            boxShadow: '0',
+          },
+        });
       });
       $sentences.eq(i).html($keys);
 

--- a/src/app.js
+++ b/src/app.js
@@ -136,7 +136,8 @@ jQuery(function($) {
     latencies.push(latency);
 
     if (shouldShowLatencyBalloon) {
-      showLatencyBalloon(latency, latencyTarget1, latencyTarget2);
+      // handleAccept の実行が遅くなる（＝文字別タイムが latency と乖離する）ので非同期で表示
+      setTimeout(() => showLatencyBalloon(latency, latencyTarget1, latencyTarget2), 0);
     }
   };
   const handleAccept = () => {

--- a/src/app.js
+++ b/src/app.js
@@ -50,7 +50,7 @@ const initializeExpandedResult = () => {
       contents: $(e).data('tooltip'),
       showDuration: 64,
       minLifetime: 0,
-      tipSize: 0,
+      tipSize: 4,
       showAnimation(d, c) { this.fadeIn(d, c); },
       css: {
         backgroundColor: '#f7f7f7',
@@ -215,7 +215,7 @@ jQuery(function($) {
           contents: toolTip,
           showDuration: 64,
           minLifetime: 0,
-          tipSize: 0,
+          tipSize: 4,
           showAnimation(d, c) { this.fadeIn(d, c); },
           css: {
             backgroundColor: '#f7f7f7',

--- a/src/app.js
+++ b/src/app.js
@@ -169,8 +169,24 @@ jQuery(function($) {
     console.log({ charTimes, missTimes });
 
     // ワード詳細
+    const $sentences = $('#exampleList li .sentence').css('cursor', 'default');
+    // TODO: ワードの途中で Esc しても詳細を表示したい
     for (let i = 0; i < finishedCount; i++) {
-      const wordLength = $('#exampleList li .sentence').eq(i).text().trim().length;
+      // 文字別タイム
+      const keys = $sentences.eq(i).text().trim().split('');
+      const $keys = keys.map((k, j) => {
+        const $key = $('<span>').text(k);
+        const loss = Math.max(...missTimes[i][j], 0);
+        if (loss > 0) {
+          return $key.attr('title', `${(charTimes[i][j] / 1000).toFixed(3)} (${(loss / 1000).toFixed(3)})`).addClass('miss');
+        } else {
+          return $key.attr('title', `${(charTimes[i][j] / 1000).toFixed(3)}`);
+        }
+      });
+      $sentences.eq(i).html($keys);
+
+      // ワード別詳細
+      const wordLength = keys.length;
       const kpm = wordLength / times[i] * 60000;
       const rkpm = (wordLength - 1) / (times[i] - latencies[i]) * 60000;
       $('#exampleList li').eq(i).append($('<div>').css({

--- a/src/app.js
+++ b/src/app.js
@@ -168,18 +168,23 @@ jQuery(function($) {
 
     // ワード詳細
     const $sentences = $('#exampleList li .sentence').css('cursor', 'default');
-    for (let i = 0; i < charTimes.filter(t => t.length > 0).length; i++) {
+    for (let i = 0; i < $sentences.size(); i++) {
+      if (charTimes[i] == null || charTimes[i].length === 0) {
+        $sentences.eq(i).fadeTo(0, 0.6);
+        continue;
+      }
+
       // 文字別タイム
       const keys = $sentences.eq(i).text().trim().split('');
       const $keys = keys.map((k, j) => {
         const $key = $('<span>').text(k);
-        if (missTimes[i][j] == null) return $key;
+        if (missTimes[i][j] == null) return $key.fadeTo(0, 0.6);
 
         const loss = Math.max(...missTimes[i][j], 0);
         if (loss > 0) {
           $key.addClass('miss');
         }
-        if (charTimes[i][j] == null) return $key;
+        if (charTimes[i][j] == null) return $key.fadeTo(0, 0.6);
 
         if (loss > 0) {
           return $key.attr('title', `${(charTimes[i][j] / 1000).toFixed(3)} (${(loss / 1000).toFixed(3)})`);


### PR DESCRIPTION
Resolves https://github.com/nohtaray/etyping-better-result/issues/6

## 機能

- [x] カーソルを当てたらタイムが出る
  - 通常
  - ミス
- [x] エスケープしたときに打ってたワードもタイムを出す

## ToDo

- [x] カーソルを当てたらタイムが出る
- [x] エスケープしたときに打ってたワードもタイムを出す
- [x] 初速のバルーン出してるとワード詳細の latency と1文字目のタイムがずれる
- [x] 見た目整える。title だと出てくるの遅い
  - [x] 普通のリザルトのほう
  - [x] 全画面のほう
- [x] ms 表示にしたほうがいいか検討: 秒で統一されてれば気にならない気がする
- [x] LT 機能でミスって終わったときに最後の文字が赤くならない
- [x] ツールチップ出したまま R でリトライするとツールチップがそのままになる
